### PR TITLE
fix: safe newline trimming and empty input validation

### DIFF
--- a/Git Auto Uploader/Git Auto Uploader.cpp
+++ b/Git Auto Uploader/Git Auto Uploader.cpp
@@ -6,6 +6,20 @@
 
 #define MAX_LENGTH 256
 
+int trim_newline(char* text) {
+    size_t len = strlen(text);
+    if (len == 0) {
+        return 0;
+    }
+
+    if (text[len - 1] == '\n') {
+        text[len - 1] = '\0';
+        len--;
+    }
+
+    return len > 0;
+}
+
 int main() {
     // Open a pipe to the command processor
     FILE* cmd = _popen("cmd", "w");
@@ -24,7 +38,11 @@ int main() {
         _pclose(cmd); // Close the pipe before exiting
         return 1;
     }
-    dir[strlen(dir) - 1] = '\0'; // Remove newline character
+    if (!trim_newline(dir)) {
+        fprintf(stderr, "Path cannot be empty.\n");
+        _pclose(cmd);
+        return 1;
+    }
 
     // Change directory
     if (fprintf(cmd, "cd \"%s\"\n", dir) < 0) {
@@ -63,7 +81,11 @@ int main() {
         _pclose(cmd);
         return 1;
     }
-    commit[strlen(commit) - 1] = '\0'; // Remove newline character
+    if (!trim_newline(commit)) {
+        fprintf(stderr, "Commit message cannot be empty.\n");
+        _pclose(cmd);
+        return 1;
+    }
 
     if (fprintf(cmd, "git commit -m \"%s\"\n", commit) < 0) {
         perror("Failed to write to command processor");
@@ -79,7 +101,11 @@ int main() {
         _pclose(cmd);
         return 1;
     }
-    remote[strlen(remote) - 1] = '\0'; // Remove newline character
+    if (!trim_newline(remote)) {
+        fprintf(stderr, "Remote URL cannot be empty.\n");
+        _pclose(cmd);
+        return 1;
+    }
 
     if (fprintf(cmd, "git remote add origin %s\n", remote) < 0) {
         perror("Failed to write to command processor");


### PR DESCRIPTION
## Summary\n- Added safe newline trimming helper with length checks\n- Added empty-input validation for path, commit message, and remote URL\n- Prevented potential out-of-bounds write on empty input\n\nCloses #7