### PR TITLE
security: validate user input before passing to cmd

### DIFF
--- a/Git Auto Uploader/Git Auto Uploader.cpp
+++ b/Git Auto Uploader/Git Auto Uploader.cpp
@@ -6,6 +6,29 @@
 
 #define MAX_LENGTH 256
 
+int trim_newline(char* text) {
+    size_t len = strlen(text);
+    if (len == 0) {
+        return 0;
+    }
+
+    if (text[len - 1] == '\n') {
+        text[len - 1] = '\0';
+        len--;
+    }
+
+    return len > 0;
+}
+
+int has_unsafe_shell_chars(const char* text) {
+    return strpbrk(text, "\"&|<>^") != NULL;
+}
+
+int is_valid_remote_url(const char* remote) {
+    return strncmp(remote, "https://github.com/", 19) == 0 ||
+           strncmp(remote, "git@github.com:", 15) == 0;
+}
+
 int main() {
     // Open a pipe to the command processor
     FILE* cmd = _popen("cmd", "w");
@@ -24,7 +47,16 @@ int main() {
         _pclose(cmd); // Close the pipe before exiting
         return 1;
     }
-    dir[strlen(dir) - 1] = '\0'; // Remove newline character
+    if (!trim_newline(dir)) {
+        fprintf(stderr, "Path cannot be empty.\n");
+        _pclose(cmd);
+        return 1;
+    }
+    if (has_unsafe_shell_chars(dir)) {
+        fprintf(stderr, "Path contains unsafe shell characters.\n");
+        _pclose(cmd);
+        return 1;
+    }
 
     // Change directory
     if (fprintf(cmd, "cd \"%s\"\n", dir) < 0) {
@@ -63,7 +95,16 @@ int main() {
         _pclose(cmd);
         return 1;
     }
-    commit[strlen(commit) - 1] = '\0'; // Remove newline character
+    if (!trim_newline(commit)) {
+        fprintf(stderr, "Commit message cannot be empty.\n");
+        _pclose(cmd);
+        return 1;
+    }
+    if (has_unsafe_shell_chars(commit)) {
+        fprintf(stderr, "Commit message contains unsafe shell characters.\n");
+        _pclose(cmd);
+        return 1;
+    }
 
     if (fprintf(cmd, "git commit -m \"%s\"\n", commit) < 0) {
         perror("Failed to write to command processor");
@@ -79,7 +120,21 @@ int main() {
         _pclose(cmd);
         return 1;
     }
-    remote[strlen(remote) - 1] = '\0'; // Remove newline character
+    if (!trim_newline(remote)) {
+        fprintf(stderr, "Remote URL cannot be empty.\n");
+        _pclose(cmd);
+        return 1;
+    }
+    if (has_unsafe_shell_chars(remote)) {
+        fprintf(stderr, "Remote URL contains unsafe shell characters.\n");
+        _pclose(cmd);
+        return 1;
+    }
+    if (!is_valid_remote_url(remote)) {
+        fprintf(stderr, "Remote URL must be a GitHub URL (https://github.com/... or git@github.com:...).\n");
+        _pclose(cmd);
+        return 1;
+    }
 
     if (fprintf(cmd, "git remote add origin %s\n", remote) < 0) {
         perror("Failed to write to command processor");


### PR DESCRIPTION
## Summary\n- Added validation for shell-sensitive characters\n- Added GitHub remote URL format validation\n- Kept existing behavior while preventing command injection vectors\n\nCloses #8